### PR TITLE
fix init command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,8 +5,6 @@ require("dotenv/config");
 const commander_1 = require("commander");
 const generate_1 = require("./commands/generate");
 const init_1 = require("./commands/init");
-console.log("hi");
-console.log("process", process.env.API_KEY);
 const program = new commander_1.Command();
 program
     .name("changelogger")

--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -31,6 +31,7 @@ async function writeToShellConfig(key, value) {
     else {
         console.log(`${key} already exists in ${targetFile}`);
     }
+    console.log(`To use API key, run: source ${targetFile}`);
 }
 function appendToGitIgnore(file) {
     const gitIgnorePath = path_1.default.resolve(".gitignore");
@@ -56,7 +57,7 @@ async function init() {
     else {
         const envPath = path_1.default.resolve(".env");
         fs_1.default.writeFileSync(envPath, `API_KEY=${apiKey}\n`);
-        console.log("Written to .env file");
-        appendToGitIgnore(envPath);
+        appendToGitIgnore(".env");
+        console.log("API key written to .env file and added to .gitignore");
     }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -31,7 +31,7 @@ async function writeToShellConfig(key: string, value: string) {
     } else {
         console.log(`${key} already exists in ${targetFile}`);
     }
-
+    console.log(`To use API key, run: source ${targetFile}`);
 }
 
 function appendToGitIgnore(file: string) {
@@ -60,8 +60,8 @@ export async function init() {
     } else {
         const envPath = path.resolve(".env");
         fs.writeFileSync(envPath, `API_KEY=${apiKey}\n`);
-        console.log("Written to .env file");
-        appendToGitIgnore(envPath);
+        appendToGitIgnore(".env");
+        console.log("API key written to .env file and added to .gitignore");
     }
 
 }


### PR DESCRIPTION
The init command had some unclear instructions. Clean up some of the processes like simply writing .env rather than the absolute path to the .gitignore and reminding users to source their target files.