### PR TITLE
preview changelog and confirm before publishing

### DIFF
--- a/cli/bin/cli.js
+++ b/cli/bin/cli.js
@@ -19,7 +19,6 @@ program
     .description('Generate changelog based on git commit history')
     .option('--from <ref>', 'Start ref (commit, tag, or branch)')
     .option('--to <ref>', 'End ref (commit, tag, or branch)', 'HEAD')
-    .option('--preview', 'Preview changelog in console')
     .option('--output <file>', 'Output file (default: stdout)')
     .option("--publish", 'Publish your changelog to changelog site')
     .action((opts) => {

--- a/cli/bin/commands/generate.js
+++ b/cli/bin/commands/generate.js
@@ -24,11 +24,13 @@ async function generateChangelog(options) {
     if (options.output) {
         fs_1.default.writeFileSync(options.output, changelog, "utf-8");
     }
-    else if (options.preview) {
-        console.log(changelog);
-    }
     else if (options.publish) {
         const latest = await git.revparse([to]);
-        await (0, publish_1.publishChangeLog)(changelog, from, latest, commits);
+        console.log("The following is a preview of your generated changelog.", changelog);
+        const publish = ((await (0, common_1.prompt)("Would you like to publish your changelog? (y/N)")).toLowerCase() === "y");
+        if (publish) {
+            await (0, publish_1.publishChangeLog)(changelog, from, latest, commits);
+        }
+        process.exit();
     }
 }

--- a/cli/bin/commands/init.js
+++ b/cli/bin/commands/init.js
@@ -6,18 +6,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.init = init;
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
-const readline_1 = __importDefault(require("readline"));
 const os_1 = __importDefault(require("os"));
-function prompt(question) {
-    const readLine = readline_1.default.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
-    return new Promise((resolve) => readLine.question(question, (answer) => {
-        readLine.close();
-        resolve(answer.trim());
-    }));
-}
+const common_1 = require("../utils/common");
 async function writeToShellConfig(key, value) {
     const shell = process.env.SHELL || "";
     const home = os_1.default.homedir();
@@ -49,8 +39,8 @@ function appendToGitIgnore(file) {
 }
 async function init() {
     console.log("Initializing requirements for your changelogger...");
-    const apiKey = await prompt("Enter your OpenRouter API key: ");
-    const storeGlobally = ((await prompt("Set your API key globally in shell config? (y/N)")).toLowerCase() === "y");
+    const apiKey = await (0, common_1.prompt)("Enter your OpenRouter API key: ");
+    const storeGlobally = ((await (0, common_1.prompt)("Set your API key globally in shell config? (y/N)")).toLowerCase() === "y");
     if (storeGlobally) {
         await writeToShellConfig("API_KEY", apiKey);
     }

--- a/cli/bin/utils/common.js
+++ b/cli/bin/utils/common.js
@@ -4,7 +4,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.summarizeChangeLog = summarizeChangeLog;
+exports.prompt = prompt;
 const axios_1 = __importDefault(require("axios"));
+const readline_1 = __importDefault(require("readline"));
 const API_KEY = process.env.API_KEY;
 const MODEL = "mistralai/mistral-7b-instruct";
 async function summarizeChangeLog(changelog) {
@@ -61,4 +63,14 @@ function cleanSummaryOutput(markdown) {
         // Remove extra spaces
         .replace(/[ \t]+$/gm, '')
         .trim();
+}
+function prompt(question) {
+    const readLine = readline_1.default.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+    return new Promise((resolve) => readLine.question(question, (answer) => {
+        readLine.close();
+        resolve(answer.trim());
+    }));
 }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -22,7 +22,6 @@ program
     .description('Generate changelog based on git commit history')
     .option('--from <ref>', 'Start ref (commit, tag, or branch)')
     .option('--to <ref>', 'End ref (commit, tag, or branch)', 'HEAD')
-    .option('--preview', 'Preview changelog in console')
     .option('--output <file>', 'Output file (default: stdout)')
     .option("--publish", 'Publish your changelog to changelog site')
     .action((opts) => {

--- a/cli/src/commands/generate.ts
+++ b/cli/src/commands/generate.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { getCommitMessages } from "../utils/git";
 import { getLastPublished, publishChangeLog } from "../utils/publish";
-import { summarizeChangeLog } from "../utils/common";
+import { prompt, summarizeChangeLog } from "../utils/common";
 import simpleGit from "simple-git";
 
 const git = simpleGit();
@@ -28,11 +28,14 @@ export async function generateChangelog( options: {
 
     if (options.output) {
         fs.writeFileSync(options.output, changelog, "utf-8");
-    } else if (options.preview) {
-        console.log(changelog)
-    } else if (options.publish) {
+    }  else if (options.publish) {
         const latest = await git.revparse([to]);
-        await publishChangeLog(changelog, from, latest, commits)
+        console.log("The following is a preview of your generated changelog.\n", changelog);
+        const publish = ((await prompt("Would you like to publish your changelog? (y/N)")).toLowerCase() === "y");
+        if (publish) {
+            await publishChangeLog(changelog, from, latest, commits);
+        }
+        process.exit();
     }
 
 }

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,21 +1,7 @@
 import fs from "fs";
 import path from "path";
-import readline from "readline";
 import os from "os";
-
-function prompt(question: string): Promise<string> {
-    const readLine = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
-
-    return new Promise((resolve) =>
-        readLine.question(question, (answer) => {
-            readLine.close();
-            resolve(answer.trim());
-        })
-    );
-}
+import { prompt } from "../utils/common";
 
 async function writeToShellConfig(key: string, value: string) {
     const shell = process.env.SHELL || "";

--- a/cli/src/utils/common.ts
+++ b/cli/src/utils/common.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import readline from "readline";
 
 const API_KEY = process.env.API_KEY;
 const MODEL = "mistralai/mistral-7b-instruct"
@@ -67,4 +68,18 @@ function cleanSummaryOutput(markdown: string): string {
       .replace(/[ \t]+$/gm, '')
       .trim();
   }
+
+export function prompt(question: string): Promise<string> {
+    const readLine = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+
+    return new Promise((resolve) =>
+        readLine.question(question, (answer) => {
+            readLine.close();
+            resolve(answer.trim());
+        })
+    );
+}
   


### PR DESCRIPTION
When publishing, it would be nice to see what you are going publish before sending it to the db for the frontend. When the user selects publish, show the preview, and prompt the user to confirm or decline if they would like to publish this changelog.